### PR TITLE
Crash related to opening Neotree in special buffers

### DIFF
--- a/lua/plugins/neotree.lua
+++ b/lua/plugins/neotree.lua
@@ -37,9 +37,38 @@ return {
         })
 
         -- Ouvrir automatiquement neo-tree dans les nouveaux tabs
+        -- Avec vérification pour éviter les conflits avec buffers spéciaux
         vim.api.nvim_create_autocmd("TabNewEntered", {
           callback = function()
-            vim.cmd("Neotree show")
+            local buftype = vim.bo.buftype
+            local filetype = vim.bo.filetype
+
+            -- Ne pas ouvrir NeoTree dans les buffers spéciaux
+            local excluded_buftypes = { "help", "terminal", "quickfix", "prompt", "nofile" }
+            local excluded_filetypes = { "neo-tree", "alpha", "dashboard", "Trouble", "toggleterm" }
+
+            -- Vérifier si le buffer est valide
+            local should_open = true
+            for _, bt in ipairs(excluded_buftypes) do
+              if buftype == bt then
+                should_open = false
+                break
+              end
+            end
+
+            for _, ft in ipairs(excluded_filetypes) do
+              if filetype == ft then
+                should_open = false
+                break
+              end
+            end
+
+            -- Ouvrir NeoTree uniquement si c'est un buffer normal
+            if should_open then
+              vim.schedule(function()
+                vim.cmd("Neotree show")
+              end)
+            end
           end,
         })
       end,


### PR DESCRIPTION
The `TabNewEntered` autocommand attempted to open NeoTree in all new tabs, including special buffers such as
`:checkhealth`, `:help`, etc. These buffers are not editable, resulting in error `E21: Cannot make changes, ‘modifiable’ is off`.

Solution implemented

  1. Buffer type check: Exclusion of special buffers (help, terminal, quickfix, prompt, nofile)
  2. Filetype check: Exclusion of special filetypes (neo-tree, alpha, dashboard, Trouble, toggleterm)
  3. Conditional opening: NeoTree only opens in normal buffers
  4. vim.schedule(): Avoids timing conflicts when creating tabs